### PR TITLE
Rust: Allow sending `SimpleCapParams` across threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 escapi.opensdf
 escapi.sdf
 /target/*
+Cargo.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+os:
+  - windows
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "escapi"
-version = "3.1.0"
+version = "3.1.1"
 authors = [
     "Daniel Abramov <dabramov@snapview.de>",
     "Oliver Schneider <git-spam-1984941651981@oli-obk.de>",
@@ -16,7 +16,7 @@ kernel32-sys = "0.2.2"
 libc = "0.2.10"
 
 [dev-dependencies]
-image = "0.13"
+image = "0.21.1"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "escapi"
-version = "3.1.1"
+version = "4.0.0"
 authors = [
     "Daniel Abramov <dabramov@snapview.de>",
     "Oliver Schneider <git-spam-1984941651981@oli-obk.de>",

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,9 @@
 
-extern crate gcc;
+extern crate cc;
 
 fn main() {
     let path = std::env::current_dir().expect("Could not get the current dir");
-    gcc::Config::new()
+    cc::Build::new()
         .cpp(true)
         .pic(true)
         .include(path.join("escapi_dll"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ struct SimpleCapParams {
     height: libc::c_uint,
 }
 
+unsafe impl Send for SimpleCapParams {}
+
 pub fn num_devices() -> usize {
     unsafe { countCaptureDevices() as usize }
 }
@@ -43,7 +45,7 @@ pub fn init(index: usize, wdt: u32, hgt: u32, desired_fps: u64) -> Result<Device
 /// The device requests BGRA format, so the frames are in BGRA.
 pub struct Device {
     device_idx: libc::c_uint,
-    buf: Box<[i32]>,
+    buf: Box<[libc::c_int]>,
     params: Box<SimpleCapParams>,
     desired_fps: u64,
 }
@@ -66,7 +68,7 @@ impl Device {
     }
     pub fn name(&self) -> String {
         let mut v = vec![0u8; 100];
-        unsafe { getCaptureDeviceName(self.device_idx, v.as_mut_ptr() as *mut i8, v.len() as i32) };
+        unsafe { getCaptureDeviceName(self.device_idx, v.as_mut_ptr() as *mut i8, v.len() as libc::c_int) };
         let null = v.iter().position(|&c| c == 0).expect("null termination character");
         v.truncate(null);
         String::from_utf8(v).expect("device name contains invalid utf8 characters")


### PR DESCRIPTION
also

* adds a travis build script (which tests building the C-part, too, as the Rust part builds that and links against it)
* small cleanups using the correct type aliases